### PR TITLE
Implement eeprom file reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bbcape_eeprom

--- a/bbcape_eeprom.c
+++ b/bbcape_eeprom.c
@@ -190,10 +190,29 @@ eeprom_write (EEPROM_HDR *e, char *fname)
 
   if ((f = fopen (fname, "wb")) == NULL)
     {
-      fprintf (stderr, "Cannot open file test.eeprom\n");
-      exit (1);
+      fprintf (stderr, "Cannot open file '%s' for writing\n", fname);
+      return -1;
     }
-  fwrite (&epr, sizeof (EEPROM_HDR), 1, f);
+  fwrite (e, sizeof (EEPROM_HDR), 1, f);
+  fclose (f);
+  _dirty = 0;
+
+  return 0;
+}
+
+int
+eeprom_read (EEPROM_HDR *e, char *fname)
+{
+  FILE *f;
+
+  if (!e) return -1;
+
+  if ((f = fopen (fname, "rb")) == NULL)
+    {
+      fprintf (stderr, "Cannot open file '%s' for reading\n", fname);
+      return -1;
+    }
+  fread (e, sizeof (EEPROM_HDR), 1, f);
   fclose (f);
   _dirty = 0;
 
@@ -232,8 +251,16 @@ cmd_general (EEPROM_HDR *e, char *buffer)
       {
 	if (strlen (buffer + 2) == 0) fname = "eeprom.bin";
 	else fname = buffer + 2;
-	fprintf (stderr, "+ Writting EEPROM to file '%s'\n\n", fname);
+	fprintf (stderr, "+ Writing EEPROM to file '%s'\n\n", fname);
 	eeprom_write (e, fname);
+	break;
+      }
+    case 'r':
+      {
+	if (strlen (buffer + 2) == 0) fname = "eeprom.bin";
+	else fname = buffer + 2;
+	fprintf (stderr, "+ Reading EEPROM from file '%s'\n\n", fname);
+	eeprom_read (e, fname);
 	break;
       }
     case 'd':


### PR DESCRIPTION
Adds/implements eeprom_read and adds .gitignore file.

The second patch also modifies eeprom_write so that it simply returns if the file to write has not opened successfully.  This should allow the user to specify another file instead of just quiting.
    
Minor spelling correction and error printing (to include filenames of unsuccessfully opened files).